### PR TITLE
Use `he` for robust HTML entity encoding/decoding

### DIFF
--- a/old_example/stringify-observ.js
+++ b/old_example/stringify-observ.js
@@ -1,4 +1,4 @@
-var decode = require("ent").decode
+var decode = require("he").decode
 var util = require("util")
 
 var normalize = require("../normalize")

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "email": "raynos2@gmail.com"
   },
   "dependencies": {
-    "global": "~2.0.7",
     "data-set": "~0.2.2",
     "element": "~0.1.4",
-    "ent": "0.0.5",
+    "global": "~2.0.7",
+    "he": "~0.4.1",
     "insert": "~1.0.1"
   },
   "devDependencies": {

--- a/plugins/raw.js
+++ b/plugins/raw.js
@@ -1,4 +1,4 @@
-var decode = require("ent").decode
+var decode = require("he").decode
 var element = require("element")
 
 module.exports = {

--- a/stringify-recur.js
+++ b/stringify-recur.js
@@ -1,5 +1,5 @@
 var util = require("util")
-var encode = require("ent").encode
+var encode = require("he").encode
 var extend = require("xtend")
 
 var unpackSelector = require("./lib/unpack-selector.js")

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -50,7 +50,7 @@ test("encodes string as text content", function (assert) {
 test("encodes scripts properly as text content", function (assert) {
     var html = stringify("<script>alert('no u')</script>")
 
-    assert.equal(html, "&lt;script&gt;alert(&apos;no u&apos;)&lt;/script&gt;")
+    assert.equal(html, "&#x3C;script&#x3E;alert(&#x27;no u&#x27;)&#x3C;/script&#x3E;")
     assert.end()
 })
 


### PR DESCRIPTION
_ent_ has [several open issues](https://github.com/substack/node-ent/issues/created_by/mathiasbynens?state=open) that are not present in [_he_](http://mths.be/he).
